### PR TITLE
Paths must start with a leading slash, response is an object, and des…

### DIFF
--- a/har_to_openapi/__main__.py
+++ b/har_to_openapi/__main__.py
@@ -15,6 +15,6 @@ if __name__ == "__main__":
 
     # Uncomment the line below to validate the generated OpenAPI spec
     # Commented out because of https://github.com/nloadholtes/har-to-openapi/issues/3
-    # validate_openapi_spec(openapi_spec)
+    validate_openapi_spec(openapi_spec)
 # with open(sys.argv[1] + ".openapi_spec.json", "w") as f:
 #     json.dump(f, openapi_spec)

--- a/har_to_openapi/converter.py
+++ b/har_to_openapi/converter.py
@@ -28,7 +28,7 @@ def har_to_openapi(har_file_path):
         method = request["method"].lower()
         url = request["url"]
 
-        path = url.replace("http://", "").replace("https://", "").split("/", 1)[-1]
+        path = "/" + url.replace("http://", "").replace("https://", "").split("/", 1)[-1]
 
         if path not in openapi_spec["paths"]:
             openapi_spec["paths"][path] = {}
@@ -37,11 +37,10 @@ def har_to_openapi(har_file_path):
         if method not in openapi_spec["paths"][path]:
             openapi_spec["paths"][path][method] = {"responses": {}}
         responses = openapi_spec["paths"][path][method]["responses"]
-        responses[response["status"]] = (
-            {
-                "description": response.get("content"),
-            },
-        )
+        responses[response["status"]] = {
+            "description": json.dumps(response.get("content")),
+        }
+
         openapi_spec["paths"][path][method]["responses"] = responses
 
     return openapi_spec


### PR DESCRIPTION
…criptions must be a string.

For this I'm just encoding the whole response description as a json-dumped string. This way one can decode the description and get to the interior information if one wishes to.

Addresses Issue #3 